### PR TITLE
fix config group name

### DIFF
--- a/src/main/java/com/doomcb/DoomColorBlindConfig.java
+++ b/src/main/java/com/doomcb/DoomColorBlindConfig.java
@@ -4,7 +4,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("example")
+@ConfigGroup("Animation Options")
 public interface DoomColorBlindConfig extends Config
 {
 	enum ProjectileTheme


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Rename ConfigGroup annotation in DoomColorBlindConfig from "example" to "Animation Options"