### PR TITLE
change group config name

### DIFF
--- a/src/main/java/com/doomcb/DoomColorBlindConfig.java
+++ b/src/main/java/com/doomcb/DoomColorBlindConfig.java
@@ -4,7 +4,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("Animation Options")
+@ConfigGroup("doomcolorblind")
 public interface DoomColorBlindConfig extends Config
 {
 	enum ProjectileTheme


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change the ConfigGroup annotation value from 'Animation Options' to 'doomcolorblind'