### PR TITLE
Add option to replace boulders with Zebak alternatives

### DIFF
--- a/src/main/java/com/doomcb/DoomColorBlindConfig.java
+++ b/src/main/java/com/doomcb/DoomColorBlindConfig.java
@@ -5,33 +5,26 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("doomcolorblind")
-public interface DoomColorBlindConfig extends Config
-{
-	enum ProjectileTheme
-	{
+public interface DoomColorBlindConfig extends Config {
+	enum ProjectileTheme {
 		INFERNO,
 		TOA,
 		OLM,
 		LEVIATHAN
 	}
 
-	@ConfigItem(
-			keyName = "projectileTheme",
-			name = "Projectile Theme",
-			description = "Choose visual style for replacing Doom projectiles"
-	)
-	default ProjectileTheme projectileTheme()
-	{
+	@ConfigItem(keyName = "projectileTheme", name = "Projectile Theme", description = "Choose visual style for replacing Doom projectiles")
+	default ProjectileTheme projectileTheme() {
 		return ProjectileTheme.TOA;
 	}
 
-	@ConfigItem(
-			keyName = "replaceMelee",
-			name = "Replace Melee Projectiles",
-			description = "Toggle whether melee projectile animations are replaced (Inferno doesn't regardless)"
-	)
-	default boolean replaceMelee()
-	{
+	@ConfigItem(keyName = "replaceMelee", name = "Replace Melee Projectiles", description = "Toggle whether melee projectile animations are replaced (Inferno doesn't regardless)")
+	default boolean replaceMelee() {
 		return false;
+	}
+
+	@ConfigItem(name = "ToA Themed Boulder", keyName = "themedRock", description = "Replace boulders with Zebak alternatives", position = 2)
+	default boolean toathemedRock() {
+		return true;
 	}
 }

--- a/src/main/java/com/doomcb/DoomColorBlindPlugin.java
+++ b/src/main/java/com/doomcb/DoomColorBlindPlugin.java
@@ -12,38 +12,34 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @Slf4j
-@PluginDescriptor(
-		name = "Doom Colorblind Helper",
-		description = "Replaces Doom projectiles with Inferno blob colors for better visibility",
-		tags = {"doom", "colorblind", "projectile"}
-)
-public class DoomColorBlindPlugin extends Plugin
-{
+@PluginDescriptor(name = "Doom Colorblind Helper", description = "Replaces Doom projectiles with Inferno blob colors for better visibility", tags = {
+		"doom", "colorblind", "projectile" })
+public class DoomColorBlindPlugin extends Plugin {
 	@Inject
 	private Client client;
 	@Inject
 	private DoomColorBlindConfig config;
 
 	@Provides
-	DoomColorBlindConfig provideConfig(ConfigManager configManager)
-	{
+	DoomColorBlindConfig provideConfig(ConfigManager configManager) {
 		return configManager.getConfig(DoomColorBlindConfig.class);
 	}
 
 	@Subscribe
-	public void onProjectileMoved(ProjectileMoved event)
-	{
+	public void onProjectileMoved(ProjectileMoved event) {
 		Projectile proj = event.getProjectile();
 		int id = proj.getId();
 
 		int replacementId = -1;
 
-		switch (id)
-		{
-			//
+		final int RANGE_ROCK_PROJECTILE = 3384;
+		final int MAGE_ROCK_PROJECTILE = 3385;
+		final int ZEBAK_RANGE_PROJECTILE = 2178;
+		final int ZEBAK_MAGE_PROJECTILE = 2176;
+
+		switch (id) {
 			case 3380: // Doom range
-				switch(config.projectileTheme())
-				{
+				switch (config.projectileTheme()) {
 					case TOA:
 						replacementId = 2241;
 						break;
@@ -60,8 +56,7 @@ public class DoomColorBlindPlugin extends Plugin
 				break;
 
 			case 3379: // Doom magic
-				switch(config.projectileTheme())
-				{
+				switch (config.projectileTheme()) {
 					case TOA:
 						replacementId = 2224;
 						break;
@@ -79,8 +74,7 @@ public class DoomColorBlindPlugin extends Plugin
 			case 3378: // Doom melee
 				if (!config.replaceMelee())
 					break;
-				switch(config.projectileTheme())
-				{
+				switch (config.projectileTheme()) {
 					case TOA:
 						replacementId = 2204;
 						break;
@@ -93,6 +87,15 @@ public class DoomColorBlindPlugin extends Plugin
 					// No Inferno Melee
 				}
 				break;
+			case RANGE_ROCK_PROJECTILE:
+				if (config.toathemedRock()) {
+					replacementId = ZEBAK_RANGE_PROJECTILE; // Zebak themed rock
+				}
+				break;
+			case MAGE_ROCK_PROJECTILE:
+				if (config.toathemedRock()) {
+					replacementId = ZEBAK_MAGE_PROJECTILE; // Zebak themed rock
+				}
 		}
 
 		if (replacementId == -1)
@@ -107,8 +110,7 @@ public class DoomColorBlindPlugin extends Plugin
 				proj.getTargetPoint(),
 				proj.getEndHeight(), proj.getTargetActor(),
 				proj.getStartCycle(), proj.getEndCycle(),
-				proj.getSlope(), proj.getStartPos()
-		);
+				proj.getSlope(), proj.getStartPos());
 
 		client.getProjectiles().addLast(replacement);
 		proj.setEndCycle(0); // Hide original


### PR DESCRIPTION
Hi, I made a similar plugin after struggling with the new boss but hadn't spotted that yours was already published.

https://github.com/runelite/plugin-hub/pull/8646

I've added a config option that my code had to allow to replace the boulder projectiles with Zebak-themed alternatives.

## Summary by Sourcery

Add a config-driven option to replace standard boulder projectiles with Zebak-themed alternatives and update projectile replacement logic accordingly

New Features:
- Add 'ToA Themed Boulder' configuration option to enable Zebak-themed boulder replacements

Enhancements:
- Introduce named constants for range and mage rock projectile IDs to improve readability in replacement logic