### PR TITLE
Add ToA themed boulder replacement option

### DIFF
--- a/src/main/java/com/doomcb/DoomColorBlindConfig.java
+++ b/src/main/java/com/doomcb/DoomColorBlindConfig.java
@@ -34,4 +34,13 @@ public interface DoomColorBlindConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			name = "ToA Themed Boulder",
+			keyName = "themedRock",
+			description = "Replace boulders with Zebak alternatives")
+	default boolean toathemedRock() {
+		return false;
+	}
+
 }

--- a/src/main/java/com/doomcb/DoomColorBlindPlugin.java
+++ b/src/main/java/com/doomcb/DoomColorBlindPlugin.java
@@ -38,8 +38,14 @@ public class DoomColorBlindPlugin extends Plugin
 
 		int replacementId = -1;
 
+		final int RANGE_ROCK_PROJECTILE = 3384;
+		final int MAGE_ROCK_PROJECTILE = 3385;
+		final int ZEBAK_RANGE_PROJECTILE = 2178;
+		final int ZEBAK_MAGE_PROJECTILE = 2176;
+
 		switch (id)
 		{
+
 			//
 			case 3380: // Doom range
 				switch(config.projectileTheme())
@@ -91,6 +97,16 @@ public class DoomColorBlindPlugin extends Plugin
 						replacementId = 2488;
 						break;
 					// No Inferno Melee
+				}
+				break;
+			case RANGE_ROCK_PROJECTILE:
+				if (config.toathemedRock()) {
+					replacementId = ZEBAK_RANGE_PROJECTILE;
+				}
+				break;
+			case MAGE_ROCK_PROJECTILE:
+				if (config.toathemedRock()) {
+					replacementId = ZEBAK_MAGE_PROJECTILE;
 				}
 				break;
 		}


### PR DESCRIPTION
Introduces a new config option to replace boulders with Zebak alternatives in the plugin. Updates logic to swap projectile IDs when the option is enabled.

## Summary by Sourcery

Introduce a configuration toggle to replace standard boulder projectiles with Zebak-themed alternatives and update the onProjectileMoved logic accordingly

New Features:
- Add 'ToA Themed Boulder' config option to enable Zebak-themed boulder replacements

Enhancements:
- Define new projectile ID constants and extend projectile handling to swap range and mage boulders with Zebak variants when the option is enabled