### PR TITLE
add unique loot sound

### DIFF
--- a/src/main/java/com/doomcb/DoomColorBlindConfig.java
+++ b/src/main/java/com/doomcb/DoomColorBlindConfig.java
@@ -3,6 +3,9 @@ package com.doomcb;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
 
 @ConfigGroup("doomcolorblind")
 public interface DoomColorBlindConfig extends Config
@@ -43,4 +46,56 @@ public interface DoomColorBlindConfig extends Config
 		return false;
 	}
 
+	@ConfigSection(
+			name = "Loot Sound",
+			description = "",
+			position = 0,
+			closedByDefault = true
+	)
+	String SECTION_LOOT_SOUND = "lootSound";
+
+	String CONFIG_KEY_LOOT_SOUND_ENABLED = "lootSoundEnabled";
+
+	@ConfigItem(
+			name = "Enable Loot Sound",
+			keyName = CONFIG_KEY_LOOT_SOUND_ENABLED,
+			description = "Play a loot sound effect on unique.",
+			position = 0,
+			section = SECTION_LOOT_SOUND
+	)
+	default boolean lootSoundEnabled()
+	{
+		return true;
+	}
+
+	String CONFIG_KEY_LOOT_SOUND_ID = "lootSoundId";
+
+	@ConfigItem(
+			name = "Sound ID",
+			keyName = CONFIG_KEY_LOOT_SOUND_ID,
+			description = "The ID of the sound effect to play." +
+				"<br>Default = 10224.",
+			position = 1,
+			section = SECTION_LOOT_SOUND
+	)
+	default int lootSoundId()
+	{
+		return 10224;
+	}
+
+	String CONFIG_KEY_LOOT_SOUND_VOLUME = "lootSoundVolume";
+
+	@Range(max = 100)
+	@Units(Units.PERCENT)
+	@ConfigItem(
+			name = "Sound Volume",
+			keyName = CONFIG_KEY_LOOT_SOUND_VOLUME,
+			description = "Loot sound volume.",
+			position = 2,
+			section = SECTION_LOOT_SOUND
+	)
+	default int lootSoundVolume()
+	{
+		return 50;
+	}
 }


### PR DESCRIPTION
Not sure if this plugin is just for colorblind stuff or general features as well (?), but here is a feature for playing a sound when there is a unique item.

## Summary by Sourcery

Add configurable loot sound feature for unique item spawns

New Features:
- Introduce a loot sound config section with enable switch, sound ID, and volume settings
- Trigger the configured sound effect when a unique burrow hole object spawns

Enhancements:
- Listen for config changes to immediately play sound when enablement or sound ID is updated
- Temporarily adjust and restore client sound preferences when playing the loot sound